### PR TITLE
Use absolute path for --from-here parameter

### DIFF
--- a/ggtags.el
+++ b/ggtags.el
@@ -519,8 +519,7 @@ With a prefix arg (non-nil DEFINITION) always find definitions."
       (ggtags-find-tag 'definition name)
     (ggtags-find-tag (format "--from-here=%d:%s"
                              (line-number-at-pos)
-                             (shell-quote-argument
-                              (file-relative-name buffer-file-name)))
+                             (buffer-file-name))
                      name)))
 
 (defun ggtags-find-reference (name)


### PR DESCRIPTION
I will explain the problem first.

Assume you have the following files:

`/projectpath/a.c`

```
void aa() {
}
```

`/projectpath/b/b.c`

```
void bb() {
    aa();
}
```

With your terminal go to the `/projectpath/` and you open the `b/b.c` from there, after that you do `M-.` over `aa();`
Then you will receive the following error:

```
global: cannot get real path name.

Global exited abnormally with code 1 at Tue Nov 12 14:10:40
```

The reason is because the `global` command is executed with the `default-directory` variable set to `/projectpath/`. The expected behavior was to executed with the `default-directory` set to `/projectpath/b`.

I don't know why this is happening, a workaround is to use the absolute path. You can merge my workaround or you can find what sets `default-directory` to `/projectpath/`.
