### PR TITLE
Require Emacs 24

### DIFF
--- a/ggtags.el
+++ b/ggtags.el
@@ -7,6 +7,7 @@
 ;; Keywords: tools, convenience
 ;; Created: 2013-01-29
 ;; URL: https://github.com/leoliu/ggtags
+;; Package-Requires: ((emacs "24"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Declaring lexical-binding:t implies that the code requires Emacs 24 or higher.

If lexical-binding is not actually required by the code, please ignore this PR and consider removing the `lexical-binding: t`. :-)

Cheers,

-Steve
