### PR TITLE
New variable ggtags-global-program

### DIFF
--- a/ggtags.el
+++ b/ggtags.el
@@ -597,9 +597,11 @@ non-nil."
                  (user-error "No tag at point"))
                 (t (substring-no-properties default))))))
 
+(defvar ggtags-global-program "global")
+
 (defun ggtags-global-build-command (cmd &rest args)
   ;; CMD can be definition, reference, symbol, grep, idutils
-  (let ((xs (append (list "global" "-v"
+  (let ((xs (append (list ggtags-global-program "-v"
                           (format "--result=%s" ggtags-global-output-format)
                           (and ggtags-global-ignore-case "--ignore-case")
                           (and (ggtags-find-project)


### PR DESCRIPTION
In ggtags-global-build-command, which builds the actual command to be
used to call global(1), the filename is hardcoded as "global".

Add ggtags-global-program variable, defaulting to "global", to allow
user to change the filename (e.g. "/opt/local/bin/global" in MacOSX
using MacPorts).

Signed-off-by: Giuseppe 'ferdy' Miceli ferdy@ferdy.it
