### PR TITLE
Adding custom variable to force global project root

### DIFF
--- a/ggtags.el
+++ b/ggtags.el
@@ -346,6 +346,11 @@ Nil means using the value of `completing-read-function'."
   :type 'function
   :group 'ggtags)
 
+(defcustom ggtags-forced-root nil
+  "Directory to be used as global root."
+  :type 'string
+  :group 'ggtags)
+
 ;; Used by ggtags-global-mode
 (defvar ggtags-global-error "match"
   "Stem of message to print when no matches are found.")
@@ -536,11 +541,12 @@ Value is new modtime if updated."
           project)
       (setq ggtags-last-default-directory default-directory)
       (setq ggtags-project-root
-            (or (ignore-errors-unless-debug
-                  (file-name-as-directory
-                   (concat (file-remote-p default-directory)
-                           ;; Resolves symbolic links
-                           (ggtags-process-string "global" "-pr"))))
+            (or ggtags-forced-root
+                (ignore-errors-unless-debug
+                 (file-name-as-directory
+                  (concat (file-remote-p default-directory)
+                          ;; Resolves symbolic links
+                          (ggtags-process-string "global" "-pr"))))
                 ;; 'global -pr' resolves symlinks before checking the
                 ;; GTAGS file which could cause issues such as
                 ;; https://github.com/leoliu/ggtags/issues/22, so


### PR DESCRIPTION
Motivation: adds the ability to use an emacs instance per project. 

This should be very useful when, for instance, using Emacs in Windows and a build that remaps the project's folders with "subst" (Windows doesn't handle large paths very well). I don't think there is an easy workaround to resolve subst-generated paths to the correct project directory (parsing subst and caching it on a hashtable is an option, or overloading "find-file" so it maps the actual file path, but that's a much broader change that I don't know if it's worth it), so an emacs instance per project is easier (and a common practice among IDEs).
