### PR TITLE
Avoid the jit-lock-mode to kick in when fontify code

### DIFF
--- a/ggtags.el
+++ b/ggtags.el
@@ -2027,6 +2027,7 @@ When finished invoke CALLBACK in BUFFER with process exit status."
                             (delay-mode-hooks (funcall mode))
                             (setq font-lock-mode t)
                             (funcall font-lock-function font-lock-mode)
+                            (setq jit-lock-mode nil)
                             (current-buffer))))
               (with-current-buffer (prepare-buffer)
                 (let ((inhibit-read-only t))


### PR DESCRIPTION
To prevent jit-lock args-out-of-range error when (erase-buffer) later.

I'm not sure if this is a bug in jit-lock-mode in emacs 25.0.50 but when *Code-Fontify* buffer already contains code from previous fontification, the (erase-buffer) will always produce following error for me.

```
Debugger entered--Lisp error: (args-out-of-range 1 76)
  put-text-property(1 76 fontified nil)
  c-extend-after-change-region(1 1 75)
  font-lock-extend-jit-lock-region-after-change(1 1 75)
  run-hook-with-args(font-lock-extend-jit-lock-region-after-change 1 1 75)
  jit-lock-after-change(1 1 75)
  erase-buffer()
  ggtags-fontify-code("      #define bool int")
```

To reproduce, try call `(ggtags-fontify-code "class Test" 'c++-mode)` twice.