### PR TITLE
Buffer no properties

### DIFF
--- a/ggtags.el
+++ b/ggtags.el
@@ -461,14 +461,14 @@ Set to nil to disable tag highlighting."
           (output (progn
                     (goto-char (point-max))
                     (skip-chars-backward " \t\n\r")
-                    (buffer-substring (point-min) (point)))))
+                    (buffer-substring-no-properties (point-min) (point)))))
       (or (zerop exit)
           (error "`%s' non-zero exit: %s" program output))
       output)))
 
 (defun ggtags-tag-at-point ()
   (pcase (funcall ggtags-bounds-of-tag-function)
-    (`(,beg . ,end) (buffer-substring beg end))))
+    (`(,beg . ,end) (buffer-substring-no-properties beg end))))
 
 ;;; Store for project info and settings
 
@@ -2090,8 +2090,9 @@ When finished invoke CALLBACK in BUFFER with process exit status."
          (show (lambda (_status)
                  (goto-char (point-min))
                  (let ((defs (cl-loop while (re-search-forward re nil t)
-                                      collect (list (buffer-substring (1+ (match-end 2))
-                                                                      (line-end-position))
+                                      collect (list (buffer-substring-no-properties
+                                                     (1+ (match-end 2))
+                                                     (line-end-position))
                                                     name
                                                     (match-string 1)
                                                     (string-to-number (match-string 2))))))
@@ -2317,7 +2318,8 @@ to nil disables displaying this information.")
         nil)
        ((and bounds (let ((completion-ignore-case nil))
                       (test-completion
-                       (buffer-substring (car bounds) (cdr bounds))
+                       (buffer-substring-no-properties
+                        (car bounds) (cdr bounds))
                        ggtags-completion-table)))
         (move-overlay o (car bounds) (cdr bounds) (current-buffer))
         (overlay-put o 'category 'ggtags-active-tag))


### PR DESCRIPTION
The second commit might be a bit overzealous - I'm not 100% sure if all those save-match-data's are necessary. But I don't think it does any harm to add them.