### PR TITLE
Correctly set `process-mark` in `ggtags-global-output`

### DIFF
--- a/ggtags.el
+++ b/ggtags.el
@@ -2037,6 +2037,7 @@ When finished invoke CALLBACK in BUFFER with process exit status."
                         (with-current-buffer (process-buffer proc)
                           (goto-char (process-mark proc))
                           (insert string)
+                          (set-marker (process-mark proc) (point))
                           (when (and (> (line-number-at-pos (point-max)) cutoff)
                                      (process-live-p proc))
                             (interrupt-process (current-buffer)))))))


### PR DESCRIPTION
This is needed when the custom filter function of the subprocess created by
`ggtags-global-output` is called multiple times. The filter function needs to
explicitly set the `process-mark` after inserting new output otherwise future
calls will insert output at the same starting location as previous calls.