### PR TITLE
Cache number of lines from previous output in `ggtags-global-output`

### DIFF
--- a/ggtags.el
+++ b/ggtags.el
@@ -1994,10 +1994,8 @@ If SYNC is non-nil, synchronously run CMDS and call CALLBACK."
                         (with-current-buffer (process-buffer proc)
                           (goto-char (process-mark proc))
                           (insert string)
-                          (save-restriction
-                            (narrow-to-region (process-mark proc) (point))
-                            (cl-incf (process-get proc :nlines)
-                                     (line-number-at-pos (1- (point)))))
+                          (cl-incf (process-get proc :nlines)
+                                   (count-lines (process-mark proc) (point)))
                           (set-marker (process-mark proc) (point))
                           (when (and (> (line-number-at-pos (point-max)) cutoff)
                                      (process-live-p proc))

--- a/ggtags.el
+++ b/ggtags.el
@@ -1994,6 +1994,10 @@ If SYNC is non-nil, synchronously run CMDS and call CALLBACK."
                         (with-current-buffer (process-buffer proc)
                           (goto-char (process-mark proc))
                           (insert string)
+                          (save-restriction
+                            (narrow-to-region (process-mark proc) (point))
+                            (cl-incf (process-get proc :nlines)
+                                     (line-number-at-pos (1- (point)))))
                           (set-marker (process-mark proc) (point))
                           (when (and (> (line-number-at-pos (point-max)) cutoff)
                                      (process-live-p proc))
@@ -2009,6 +2013,7 @@ If SYNC is non-nil, synchronously run CMDS and call CALLBACK."
     (and cutoff (set-process-filter proc filter))
     (set-process-sentinel proc sentinel)
     (process-put proc :callback-done nil)
+    (process-put proc :nlines 0)
     (if sync (while (not (process-get proc :callback-done))
                (accept-process-output proc 1))
       proc)))


### PR DESCRIPTION
`line-number-at-pos` grows linearly with the number of lines in a buffer so
cache the computation of the number of lines and only call `line-number-at-pos`
when the buffer is narrowed to new output produced by Global that has not been
processed yet.