### PR TITLE
fix xref support for emacs 28

### DIFF
--- a/ggtags.el
+++ b/ggtags.el
@@ -2369,12 +2369,12 @@ Function `ggtags-eldoc-function' disabled for eldoc in current buffer: %S" err))
 
 (defconst ggtags--xref-limit 1000)
 
-(defclass ggtags-xref-location (xref-file-location)
-  ((project-root :type string :initarg :project-root)))
+(cl-defstruct (ggtags-xref-location
+               (:constructor ggtags-make-xref-location (file line column project-root)))
+  file project-root)
 
 (cl-defmethod xref-location-group ((l ggtags-xref-location))
-  (with-slots (file project-root) l
-    (file-relative-name file project-root)))
+  (file-relative-name (ggtags-xref-location-file l) (ggtags-xref-location-project-root l)))
 
 (defun ggtags--xref-backend ()
   (and (ggtags-find-project)
@@ -2415,12 +2415,11 @@ properties in the summary text of each xref."
    and when column
    collect (xref-make
             summary
-            (make-instance
-             'ggtags-xref-location
-             :file file
-             :line line
-             :column column
-             :project-root root))))
+            (ggtags-make-xref-location
+             file
+             line
+             column
+             root))))
 
 (defun ggtags--xref-find-tags (tag cmd)
   "Find xrefs of TAG using Global CMD.


### PR DESCRIPTION
https://github.com/emacs-mirror/emacs/commit/86da812afb2572c7fead2bb07570b976bffd7c55
removes EIEIO support from xref.el and breaks ggtags.el

This commit fixes ggtags to be compatible with emacs 28