### PR TITLE
Fix #218: make `xref-find-definitions' work correctly in symlinks

### DIFF
--- a/ggtags.el
+++ b/ggtags.el
@@ -2417,7 +2417,7 @@ properties in the summary text of each xref."
    with re = (cadr (assq 'grep ggtags-global-error-regexp-alist-alist))
    while (re-search-forward re nil t)
    for summary = (buffer-substring (1+ (match-end 2)) (line-end-position))
-   for file = (expand-file-name (file-truename (match-string 1)))
+   for file = (file-truename (match-string 1))
    for line = (string-to-number (match-string 2))
    for column = (string-match-p tag summary)
    if colored do (setq summary (ansi-color-apply summary)) end

--- a/ggtags.el
+++ b/ggtags.el
@@ -2417,7 +2417,7 @@ properties in the summary text of each xref."
    with re = (cadr (assq 'grep ggtags-global-error-regexp-alist-alist))
    while (re-search-forward re nil t)
    for summary = (buffer-substring (1+ (match-end 2)) (line-end-position))
-   for file = (expand-file-name (match-string 1))
+   for file = (expand-file-name (file-truename (match-string 1)))
    for line = (string-to-number (match-string 2))
    for column = (string-match-p tag summary)
    if colored do (setq summary (ansi-color-apply summary)) end

--- a/ggtags.el
+++ b/ggtags.el
@@ -2417,7 +2417,7 @@ properties in the summary text of each xref."
    with re = (cadr (assq 'grep ggtags-global-error-regexp-alist-alist))
    while (re-search-forward re nil t)
    for summary = (buffer-substring (1+ (match-end 2)) (line-end-position))
-   for file = (file-truename (match-string 1))
+   for file = (expand-file-name (match-string 1) root)
    for line = (string-to-number (match-string 2))
    for column = (string-match-p tag summary)
    if colored do (setq summary (ansi-color-apply summary)) end


### PR DESCRIPTION
This pull request is to fix #218 . I tested it on example project on #218 and this worked fine.
I hope this is helpful.
Thanks.